### PR TITLE
sync: anse-app/chatgpt-demo/pull/441 - fix: #428

### DIFF
--- a/hack/docker-env-replace.sh
+++ b/hack/docker-env-replace.sh
@@ -22,7 +22,7 @@ for file in $(find ./dist -type f -name "*.mjs"); do
   s/({}).HEAD_SCRIPTS/\"$head_scripts\"/g;
   s/({}).PUBLIC_SECRET_KEY/\"$public_secret_key\"/g;
   s/({}).OPENAI_API_MODEL/\"$openai_api_model\"/g;
-  s/process.env.SITE_PASSWORD/\"$site_password\"/g" $file > tmp
+  s/({}).SITE_PASSWORD/\"$site_password\"/g" $file > tmp
   mv tmp $file
 done
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro'
 import Header from '../components/Header.astro'
-import Footer from '../components/Footer.astro'
 import Generator from '../components/Generator'
 import '../message.css'
 import 'katex/dist/katex.min.css'
@@ -12,7 +11,6 @@ import 'highlight.js/styles/atom-one-dark.css'
   <main >
     <Header />
     <Generator client:load />
-    <Footer />
   </main>
 </Layout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro'
 import Header from '../components/Header.astro'
+import Footer from '../components/Footer.astro'
 import Generator from '../components/Generator'
 import '../message.css'
 import 'katex/dist/katex.min.css'
@@ -11,6 +12,7 @@ import 'highlight.js/styles/atom-one-dark.css'
   <main >
     <Header />
     <Generator client:load />
+    <Footer />
   </main>
 </Layout>
 


### PR DESCRIPTION
### Description

与[anse-app/chatgpt-demo #441](https://github.com/anse-app/chatgpt-demo/pull/441)同步

修复[anse-app/chatgpt-demo #428](https://github.com/anse-app/chatgpt-demo/issues/428)「Docker 部署的时候 SITE_PASSWORD 没有解析成功」的问题

### Linked Issues

[anse-app/chatgpt-demo #428](https://github.com/anse-app/chatgpt-demo/issues/428)

